### PR TITLE
chore: nâng version lên 2026.8.17

### DIFF
--- a/custom_components/zalo_bot/manifest.json
+++ b/custom_components/zalo_bot/manifest.json
@@ -13,5 +13,5 @@
     "requests"
   ],
   "single_config_entry": true,
-  "version": "2026.5.10"
+  "version": "2026.8.17"
 }


### PR DESCRIPTION
`manifest.json` vẫn ghi `2026.5.10`, trong khi bản vá gửi nhiều ảnh (commit e6a4572, 01/08) đã vào `main`.

Repo không có release và `hacs.json` không khai `zip_release`, nên HACS bám theo nhánh và so bằng commit — người dùng vẫn nhận được bản vá. Nhưng Home Assistant hiển thị số phiên bản lấy từ `manifest.json`, nên nhìn vào giao diện không trả lời được câu "máy tôi đã có bản sửa chưa".

Một dòng, không đổi gì khác. Đã kiểm JSON hợp lệ.